### PR TITLE
Fix issue #3

### DIFF
--- a/src/Cursoriam.Analyzers.Package/Cursoriam.Analyzers.Package.csproj
+++ b/src/Cursoriam.Analyzers.Package/Cursoriam.Analyzers.Package.csproj
@@ -9,15 +9,13 @@
 
   <PropertyGroup>
     <PackageId>Cursoriam.Analyzers</PackageId>
-    <PackageVersion>1.0.0.0</PackageVersion>
+    <PackageVersion>1.0.1.0</PackageVersion>
     <Authors>Wilfried Boos</Authors>
-    <!--<PackageLicenseUrl>http://LICENSE_URL_HERE_OR_DELETE_THIS_LINE</PackageLicenseUrl>-->
     <PackageProjectUrl>https://github.com/wilfriedb/dotnet-analyzers</PackageProjectUrl>
-    <!--<PackageIconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</PackageIconUrl>-->
     <RepositoryUrl>https://github.com/wilfriedb/dotnet-analyzers</RepositoryUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Description>An C# analyzer that flags discarded Tasks</Description>
-    <PackageReleaseNotes>Summary of changes made in this release of the package.</PackageReleaseNotes>
+    <Description>A C# analyzer that flags discarded Tasks</Description>
+    <PackageReleaseNotes>Initial release</PackageReleaseNotes>
     <Copyright>Copyright 2023 Cursoriam</Copyright>
     <PackageTags>analyzer;analyzers</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>

--- a/src/Cursoriam.Analyzers.Test/DiscardedTaskAnalyzerUnitTests.cs
+++ b/src/Cursoriam.Analyzers.Test/DiscardedTaskAnalyzerUnitTests.cs
@@ -91,7 +91,7 @@ internal class TestSubject
     }
 
     // Comment1 must stay in place
-    async public Task MethodWithCodeToAnalyze()
+    public async Task MethodWithCodeToAnalyze()
     {
         var t = new TestSubject();
         // Comment2 must not disappear
@@ -143,7 +143,7 @@ internal class TestSubject
     }
 
     // Comment1 must stay in place
-    async public Task MethodWithCodeToAnalyze()
+    public async Task MethodWithCodeToAnalyze()
     {
         var t = new TestSubject();
         // Comment2 must not disappear
@@ -301,7 +301,7 @@ internal class TestSubject
         return Task.CompletedTask;
     }
 
-    async public Task<int> MethodWithCodeToAnalyze()
+    public async Task<int> MethodWithCodeToAnalyze()
     {
         var t = new TestSubject();
         await t.TestMethod();
@@ -358,7 +358,7 @@ internal class TestSubject
         return Task.FromResult(0);
     }
 
-    async public Task<UserDefinedClass> MethodWithCodeToAnalyze()
+    public async Task<UserDefinedClass> MethodWithCodeToAnalyze()
     {
         var t = new TestSubject();
         _ = await t.TestMethod();
@@ -423,7 +423,7 @@ internal class TestSubject
     // Comment1 should stay here
     [DoNothing]
     // Comment2 should stay here
-    async public Task MethodWithCodeToAnalyze()
+    public async Task MethodWithCodeToAnalyze()
     {
         var t = new TestSubject();
         await t.TestMethodAsync();
@@ -493,5 +493,112 @@ internal class TestSubject
         var expectedDiagnostic = VerifyCS.Diagnostic(DiscardedTaskAnalyzer.DiagnosticId).WithLocation(0); // Location 0 is the {|#0: |} syntax
         await VerifyCS.VerifyCodeFixAsync(testCode, expectedDiagnostic, fixedTestCode);
     }
-}
 
+
+    [TestMethod]
+    public async Task TestMostSimpleVoidCodeWithoutModifier_OneWarningAndFixAsync()
+    {
+        var testCode = @"
+using System.Threading.Tasks;
+
+namespace ConsoleApplication1;
+
+internal class TestSubject
+{
+    public Task TestMethodAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    // Comment1 must stay in place
+    void MethodWithCodeToAnalyze()
+    {
+        var t = new TestSubject();
+        // Comment2 must not disappear
+        {|#0:_ = t.TestMethodAsync()|};
+        // Comment3 must not disappear
+    }
+}";
+
+        var fixedTestCode = @"
+using System.Threading.Tasks;
+
+namespace ConsoleApplication1;
+
+internal class TestSubject
+{
+    public Task TestMethodAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    // Comment1 must stay in place
+    async Task MethodWithCodeToAnalyze()
+    {
+        var t = new TestSubject();
+        // Comment2 must not disappear
+        await t.TestMethodAsync();
+        // Comment3 must not disappear
+    }
+}";
+
+        var expectedDiagnostic = VerifyCS.Diagnostic(DiscardedTaskAnalyzer.DiagnosticId).WithLocation(0); // Location 0 is the {|#0: |} syntax
+        await VerifyCS.VerifyCodeFixAsync(testCode, expectedDiagnostic, fixedTestCode);
+    }
+
+    [TestMethod]
+    public async Task TestMostSimpleIntCodeWithoutModifier_OneWarningAndFixAsync()
+    {
+        var testCode = @"
+using System.Threading.Tasks;
+
+namespace ConsoleApplication1;
+
+internal class TestSubject
+{
+    public Task TestMethodAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    // Comment1 must stay in place
+    int MethodWithCodeToAnalyze()
+    // Comment2 must not disappear
+    {
+        var t = new TestSubject();
+        {|#0:_ = t.TestMethodAsync()|};
+
+        return 0;
+    }
+    // Comment 3 must stay in place
+}";
+
+        var fixedTestCode = @"
+using System.Threading.Tasks;
+
+namespace ConsoleApplication1;
+
+internal class TestSubject
+{
+    public Task TestMethodAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    // Comment1 must stay in place
+    async Task<int> MethodWithCodeToAnalyze()
+    // Comment2 must not disappear
+    {
+        var t = new TestSubject();
+        await t.TestMethodAsync();
+
+        return 0;
+    }
+    // Comment 3 must stay in place
+}";
+
+        var expectedDiagnostic = VerifyCS.Diagnostic(DiscardedTaskAnalyzer.DiagnosticId).WithLocation(0); // Location 0 is the {|#0: |} syntax
+        await VerifyCS.VerifyCodeFixAsync(testCode, expectedDiagnostic, fixedTestCode);
+    }
+
+}

--- a/src/Cursoriam.Analyzers/CodeFixes/DiscardedTaskAnalyzerCodeFixProvider.cs
+++ b/src/Cursoriam.Analyzers/CodeFixes/DiscardedTaskAnalyzerCodeFixProvider.cs
@@ -136,7 +136,8 @@ namespace Cursoriam.Analyzers.CodeFixes
                 // Make a generic Task
                 var syntaxList = SyntaxFactory.SeparatedList(new[] { returnType });
                 var genericTaskType = SyntaxFactory.GenericName(taskSyntax.Identifier, SyntaxFactory.TypeArgumentList(syntaxList));
-                newMethod = updatedMethod.WithModifiers(newModifiers).WithReturnType(genericTaskType).WithLeadingTrivia(method.GetLeadingTrivia());
+                newMethod = updatedMethod.WithModifiers(newModifiers).WithReturnType(genericTaskType)
+                    .WithLeadingTrivia(method.GetLeadingTrivia());
             }
 
             var asyncAwaitRoot = rootWithAwaitAdded.ReplaceNode(updatedMethod, newMethod);

--- a/src/Cursoriam.Analyzers/CodeFixes/DiscardedTaskAnalyzerCodeFixProvider.cs
+++ b/src/Cursoriam.Analyzers/CodeFixes/DiscardedTaskAnalyzerCodeFixProvider.cs
@@ -159,8 +159,8 @@ namespace Cursoriam.Analyzers.CodeFixes
             if (typeInfo.Type is INamedTypeSymbol namedTypeSymbol && namedTypeSymbol.IsGenericType && !namedTypeSymbol.IsUnboundGenericType)
             {
                 //  We keep the discard
-                var na = SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, assignment.Left, awaitExpressionSyntax).WithTriviaFrom(assignment);
-                rootWithAwaitAdded = originalRoot.ReplaceNode(assignment, na);
+                var newAssignment = SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, assignment.Left, awaitExpressionSyntax).WithTriviaFrom(assignment);
+                rootWithAwaitAdded = originalRoot.ReplaceNode(assignment, newAssignment);
             }
             else
             {


### PR DESCRIPTION
This pull request fixes the issue that the order of the modifiers after the fix is not as in csharp_preferred_modifier_order: [ide0036](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0036)

Also it fixes a bug where when the containing method has no modifiers at all the trivia ended up at the wrong place.